### PR TITLE
Include re.UNICODE flag in the STRIP_WHITESPACE regular expression

### DIFF
--- a/softhyphen/html.py
+++ b/softhyphen/html.py
@@ -48,7 +48,7 @@ def hyphenate(html, language='en-us', hyphenator=None, blacklist_tags=(
 # Constants
 SOFT_HYPHEN = r'&shy;'
 SPACE = r' '
-STRIP_WHITESPACE = re.compile('\w+', re.MULTILINE)
+STRIP_WHITESPACE = re.compile('\w+', re.MULTILINE|re.UNICODE)
 
 def hyphenate_element(soup, hyphenator, blacklist_tags):
     """


### PR DESCRIPTION
Without this flag, the regular expression filters out all non-latin characters from the string (i.e. rendering the module useless for Cyrillic languages).
