### PR TITLE
cached_softhyphen and defaulting to language = active translation

### DIFF
--- a/softhyphen/templatetags/softhyphen_tags.py
+++ b/softhyphen/templatetags/softhyphen_tags.py
@@ -26,7 +26,6 @@ def cached_softhyphen(value, language=translation.get_language()):
     """
     Hyphenates html and caches result.
     """
-    print translation.get_language()
     md5 = hashlib.md5()
     md5.update(value.encode('utf-8'))
     digest = md5.hexdigest()


### PR DESCRIPTION
Hi!

At first, thanks for sharing this great app!
I added a template filter "cached_softhyphen".
It makes the template filter more useable or at least a more considerable choice in production for cases where saving to the database is not an option. For example if you don´t want to fork an App.
I also made the language param default to the active language.

Maybe you like it :)

Cheers,

Lenz
