### PR TITLE
Fixes #22

### DIFF
--- a/softhyphen/html.py
+++ b/softhyphen/html.py
@@ -11,10 +11,6 @@ import six
 from bs4 import BeautifulSoup
 from .hyphenator import Hyphenator
 from bs4.element import PreformattedString
-from django.conf import settings
-
-BEAUTIFULSOUP_BUILDER_FEATURES = getattr(settings,
-    'SOFTHYPHEN_BEAUTIFULSOUP_BUILDER_FEATURES', ['html.parser'])
 
 
 class DontEscapeDammit(PreformattedString):
@@ -55,7 +51,7 @@ def hyphenate(html, language='en-us', hyphenator=None, blacklist_tags=(
         hyphenator = get_hyphenator_for_language(language)
 
     # Create HTML tree
-    soup = BeautifulSoup(html, features=BEAUTIFULSOUP_BUILDER_FEATURES)
+    soup = BeautifulSoup(html, "html.parser")
 
     # Recursively hyphenate each element
     hyphenate_element(soup, hyphenator, blacklist_tags)

--- a/softhyphen/html.py
+++ b/softhyphen/html.py
@@ -11,6 +11,10 @@ import six
 from bs4 import BeautifulSoup
 from .hyphenator import Hyphenator
 from bs4.element import PreformattedString
+from django.conf import settings
+
+BEAUTIFULSOUP_BUILDER_FEATURES = \
+    getattr(settings, 'SOFTHYPHEN_BEAUTIFULSOUP_BUILDER_FEATURES', ['html.parser'])
 
 
 class DontEscapeDammit(PreformattedString):
@@ -51,7 +55,7 @@ def hyphenate(html, language='en-us', hyphenator=None, blacklist_tags=(
         hyphenator = get_hyphenator_for_language(language)
 
     # Create HTML tree
-    soup = BeautifulSoup(html)
+    soup = BeautifulSoup(html, features=BEAUTIFULSOUP_BUILDER_FEATURES)
 
     # Recursively hyphenate each element
     hyphenate_element(soup, hyphenator, blacklist_tags)

--- a/softhyphen/html.py
+++ b/softhyphen/html.py
@@ -13,8 +13,8 @@ from .hyphenator import Hyphenator
 from bs4.element import PreformattedString
 from django.conf import settings
 
-BEAUTIFULSOUP_BUILDER_FEATURES = \
-    getattr(settings, 'SOFTHYPHEN_BEAUTIFULSOUP_BUILDER_FEATURES', ['html.parser'])
+BEAUTIFULSOUP_BUILDER_FEATURES = getattr(settings,
+    'SOFTHYPHEN_BEAUTIFULSOUP_BUILDER_FEATURES', ['html.parser'])
 
 
 class DontEscapeDammit(PreformattedString):


### PR DESCRIPTION
**django-softhyphen** uses the excellent **Beautifulsoap** library to parse the given HTML content. Depending on which libraries are installed on your system, **Beautifulsoap** uses an alternative parser, which wraps the HTML fragment into ``<html><head>...</head><body>...</body></html>``. This side effect normally is undesired. In case you explicitly want to use an alternative HTML parser, use the configuration setting ``SOFTHYPHEN_BEAUTIFULSOUP_BUILDER_FEATURES = [other HTML parser(s)]``.