### PR TITLE
Improve language parameter handling.

### DIFF
--- a/softhyphen/html.py
+++ b/softhyphen/html.py
@@ -9,6 +9,7 @@ import os
 import re
 import six
 from bs4 import BeautifulSoup
+from django.utils.translation import get_language
 from .hyphenator import Hyphenator
 from bs4.element import PreformattedString
 
@@ -23,7 +24,7 @@ class DontEscapeDammit(PreformattedString):
         return self.PREFIX + self + self.SUFFIX
 
 
-def hyphenate(html, language='en-us', hyphenator=None, blacklist_tags=(
+def hyphenate(html, language=None, hyphenator=None, blacklist_tags=(
     'code', 'tt', 'pre', 'head', 'title', 'script', 'style', 'meta', 'object',
     'embed', 'samp', 'var', 'math', 'select', 'option', 'input', 'textarea',
     'span')
@@ -47,6 +48,15 @@ def hyphenate(html, language='en-us', hyphenator=None, blacklist_tags=(
     u'<p>The brave men, liv&shy;ing and dead.</p>'
     """
     # Load hyphenator if one is not provided
+    if not language:
+        language = get_language()
+
+    if language == 'en':
+        language = 'en-us'
+    elif '-' not in language:
+        # Language code is "en-us", "it-it", "nl-nl"
+        language = "{0}-{0}".format(language)
+
     if not hyphenator:
         hyphenator = get_hyphenator_for_language(language)
 

--- a/softhyphen/templatetags/softhyphen_tags.py
+++ b/softhyphen/templatetags/softhyphen_tags.py
@@ -5,7 +5,7 @@ register = template.Library()
 
 
 @register.filter
-def softhyphen(value, language="en-us"):
+def softhyphen(value, language=None):
     """
     Hyphenates html.
     """


### PR DESCRIPTION
Currently all hypenation calls enforce the use of `en-us` as language, while the current text or site might not even use `en-us` at all. Instead, I'd like to propose to read the value from the current Django language instead. (which is typically set to `LANGUAGE_CODE`, but can be switched at template/request level).

To make sure the current Django language can be passed, any existing locale will be translated to their proper `lang-countrycode` format (en => en-us, nl => nl-nl, etc..). This causes django-softhyphen to do the right thing in most cases.
