### PR TITLE
Remove closing line break tags

### DIFF
--- a/softhyphen/html.py
+++ b/softhyphen/html.py
@@ -66,7 +66,7 @@ def hyphenate(html, language=None, hyphenator=None, blacklist_tags=(
     # Recursively hyphenate each element
     hyphenate_element(soup, hyphenator, blacklist_tags)
 
-    return six.text_type(soup)
+    return fix_linebreaks(six.text_type(soup))
 
 
 # Constants
@@ -149,6 +149,10 @@ def get_hyphenator_for_language(language):
         'dicts/%s.dic' % DICTIONARIES[language]
     )
     return Hyphenator(path)
+
+
+def fix_linebreaks(html):
+    return html.replace('</br>', '')
 
 
 # Test when standalone

--- a/softhyphen/tests.py
+++ b/softhyphen/tests.py
@@ -102,3 +102,14 @@ class SoftHyphenTest(TestCase):
             after,
             six.u('<h1>\u043f\u0435&shy;\u0440\u0435.</h1>')
         )
+
+    def test_linebreak_fix(self):
+        '''
+        Test that <br> tags are handled correctly.
+        '''
+        before = six.u('<p>Breaking<br>changes</p>')
+        after = hyphenate(before)
+        self.failUnlessEqual(
+            after,
+            six.u('<p>Break&shy;ing<br>changes</p>')
+        )


### PR DESCRIPTION
Beautifulsoup adds unwanted closing line break tags when opening linebreak tags are present.
This might rather be a bug in beautifulsoup, but it seems unlikely to get fixed there (see http://henry.precheur.org/python/beautiful_soup.html).
Also, I am not very happy with this workaround for the problem, but other alternatives seem worse (e.g. using lxml instead of html.parser also works around the problem, as lxml replaces `<br>` with `<br/>`).